### PR TITLE
Parse input angle into Float before assigning.

### DIFF
--- a/jquery.ui.rotatable.js
+++ b/jquery.ui.rotatable.js
@@ -277,7 +277,7 @@
       if (this.options.degrees) {
         this.elementCurrentAngle = this._angleInRadians(this.options.degrees)
       }
-      this.elementCurrentAngle = this.options.radians || this.options.angle || 0
+      this.elementCurrentAngle = parseFloat(this.options.radians) || parseFloat(this.options.angle) || 0
       this._performRotation(this.elementCurrentAngle)
     },
 


### PR DESCRIPTION
It may happen that developer is passing a dynamic value which is read from an input field. So the input maybe string but actually is a number. Better to parse it before using.